### PR TITLE
Add essentials checklist

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ The application is built to be responsive, ensuring a seamless experience across
 
 - Once all meals are selected, click the "Plan my meals" button.
 - The application will display a shopping list with all the ingredients required for the selected meals.
+- Optionally tick items in the **Add Essentials** section (e.g. Fabric Conditioner, Bin Bags) to include them in the list.
 
 ## Customisation
 

--- a/app.js
+++ b/app.js
@@ -160,6 +160,15 @@ function generateShoppingList() {
   }))
   .then(() => {
     // Now that all ingredients have been gathered, display the shopping list
+    document.querySelectorAll('#essentials input[type="checkbox"]:checked').forEach(cb => {
+      const item = cb.value;
+      if (shoppingList.has(item)) {
+        shoppingList.set(item, shoppingList.get(item) + 1);
+      } else {
+        shoppingList.set(item, 1);
+      }
+    });
+
     displayShoppingList(Array.from(shoppingList));
   });
 }

--- a/manner.html
+++ b/manner.html
@@ -130,6 +130,15 @@ details[open] > summary::before {
   margin-bottom: 15px;
 }
 
+#essentials {
+  padding: 20px;
+}
+
+#essentials label {
+  display: block;
+  margin-bottom: 8px;
+}
+
 </style>
 </head>
 <body>
@@ -220,11 +229,20 @@ details[open] > summary::before {
         <select id="lunch-sunday" aria-label="Select lunch for sunday">
         </select>
       </div>
-    </div>
-    </details>
-    
+      </div>
+      </details>
 
-    <button id="plan-meals" class=".btn">Plan My Meals</button>
+      <details>
+        <summary>Add Essentials</summary>
+        <div id="essentials">
+          <label><input type="checkbox" value="Fabric Conditioner"> Fabric Conditioner</label><br>
+          <label><input type="checkbox" value="Bin Bags"> Bin Bags</label><br>
+          <label><input type="checkbox" value="Toilet Roll"> Toilet Roll</label><br>
+          <label><input type="checkbox" value="Washing Up Liquid"> Washing Up Liquid</label>
+        </div>
+      </details>
+
+      <button id="plan-meals" class=".btn">Plan My Meals</button>
   </div>
 
   <div id="errorMessages" style="color: red; margin: 10px 0;"></div>


### PR DESCRIPTION
## Summary
- add optional `Add Essentials` checklist to allow extra items
- include those essentials in the generated shopping list
- document how to use the new checklist feature

## Testing
- `npm test` *(fails: Missing script)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6847e364730c8321af0ba08541d20629